### PR TITLE
Corrected Pinkcoin details.

### DIFF
--- a/src/janin.currency.js
+++ b/src/janin.currency.js
@@ -233,7 +233,7 @@ janin.currencies = [
     janin.currency.createCurrency ("PHCoin",              0x37, 0xb7, "7",    "U"    , "P9e6c714JUHUfuBVHSS36eqaxGCN6X8nyU"),
     janin.currency.createCurrency ("PhoenixCoin",         0x38, 0xb8, "7",    "U"    , "PsaaD2mLfAPUJXhMYdC1DBavkJhZj14k6X"),
     janin.currency.createCurrency ("PiggyCoin",           0x76, 0xf6, "9",    "d"    , "pqXotCKo6mmtYtLY5mi9uEW22mPFgKoLvx"),
-    janin.currency.createCurrency ("Pinkcoin",            0x3,  0x83, "[RQP]","L"    , "2Xgy8K2n5cVmnm8Se2rDojQ1GdfHdktx8r"),
+    janin.currency.createCurrency ("Pinkcoin",            0x03, 0x83, "5",    "L"    , "2Xgy8K2n5cVmnm8Se2rDojQ1GdfHdktx8r"),
     janin.currency.createCurrency ("PIVX",                0x1e, 0xd4, "8",    "Y"    , "DSiCurCzgdzqSP1urFg3VZJfrpyhMWjEAp"),
     janin.currency.createCurrency ("Peercoin",            0x37, 0xb7, "7",    "U"    , "PSnwUwknbmqUU1GCcM1DNxcANqihpdt3tW"),
     janin.currency.createCurrency ("Potcoin",             0x37, 0xb7, "7",    "U"    , "PQcMNuCdeooMcS5H3DGwxXnSE2kmyVMU39"),


### PR DESCRIPTION
Replaced "0x3" with "0x03" and "[RQP]" with "5".